### PR TITLE
Add minimal React prototype for DARK playbook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
-# dark-leverage-sales-playbook
+# DARK Leverage Sales Playbook
+
+This repository contains a very small prototype for the interactive sales playbook described in the prompt.
+
+## Getting Started
+
+Install dependencies and start a simple server:
+
+```bash
+npm start
+```
+
+Then open `public/index.html` in your browser.
+
+The prototype currently implements a basic broker income calculator using React and Tailwind via CDN.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "dark-leverage-sales-playbook",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "start": "npx serve public"
+  },
+  "dependencies": {}
+}

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>DARK Sales Playbook</title>
+  <link href="https://cdn.jsdelivr.net/npm/tailwindcss@3.4.4/dist/tailwind.min.css" rel="stylesheet">
+  <script src="https://unpkg.com/react@18/umd/react.development.js" crossorigin></script>
+  <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js" crossorigin></script>
+</head>
+<body class="bg-gray-100 text-gray-800">
+  <div id="root"></div>
+  <script type="module" src="../src/main.js"></script>
+</body>
+</html>

--- a/src/App.js
+++ b/src/App.js
@@ -1,0 +1,11 @@
+import Calculator from './components/Calculator.js';
+
+export default function App() {
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl font-bold mb-4">DARK Leverage Sales Playbook</h1>
+      <p className="mb-4">Welcome! Adjust the values below to see potential income.</p>
+      <Calculator />
+    </div>
+  );
+}

--- a/src/components/Calculator.js
+++ b/src/components/Calculator.js
@@ -1,0 +1,62 @@
+import { useState } from 'react';
+
+export default function Calculator() {
+  const [annualDeals, setAnnualDeals] = useState(20);
+  const [averageDealSize, setAverageDealSize] = useState(1000000);
+  const [successRate, setSuccessRate] = useState(0.4);
+
+  const result = calculateBrokerIncome({
+    annualDeals,
+    averageDealSize,
+    successRate,
+  });
+
+  return (
+    <div className="p-4 bg-white rounded shadow-md mt-4">
+      <h2 className="text-xl font-semibold mb-2">Broker Income Calculator</h2>
+      <div className="space-y-2">
+        <label className="block">
+          Deals per year: {annualDeals}
+          <input type="range" min="10" max="50" value={annualDeals} onChange={e => setAnnualDeals(parseInt(e.target.value, 10))} className="w-full" />
+        </label>
+        <label className="block">
+          Average deal size ($):
+          <input type="number" value={averageDealSize} onChange={e => setAverageDealSize(parseInt(e.target.value, 10))} className="w-full border" />
+        </label>
+        <label className="block">
+          Success rate: {Math.round(successRate*100)}%
+          <input type="range" min="0.2" max="0.7" step="0.01" value={successRate} onChange={e => setSuccessRate(parseFloat(e.target.value))} className="w-full" />
+        </label>
+      </div>
+      <div className="mt-4">
+        <p>Current Income: ${result.currentIncome.toLocaleString()}</p>
+        <p>Total Additional Income: ${result.totalAdditionalIncome.toLocaleString()}</p>
+      </div>
+    </div>
+  );
+}
+
+export function calculateBrokerIncome(inputs) {
+  const { annualDeals, averageDealSize, successRate, commissionRate = 0.08 } = inputs;
+  const currentIncome = annualDeals * successRate * averageDealSize * commissionRate;
+  const failedDeals = annualDeals * (1 - successRate);
+  const darkReferrals = Math.floor(failedDeals * 0.6);
+  const standardReferrals = Math.floor(darkReferrals * 0.4);
+  const premiumReferrals = Math.floor(darkReferrals * 0.4);
+  const eliteReferrals = Math.floor(darkReferrals * 0.2);
+  const referralIncome =
+    standardReferrals * 25000 * 0.15 +
+    premiumReferrals * 65000 * 0.15 +
+    eliteReferrals * 125000 * 0.15;
+  const recurringIncome = darkReferrals * 2000 * 0.15 * 12;
+  const equityUpside = darkReferrals * 150000;
+  return {
+    currentIncome,
+    failedDeals,
+    darkReferrals,
+    referralIncome,
+    recurringIncome,
+    equityUpside,
+    totalAdditionalIncome: referralIncome + recurringIncome + equityUpside,
+  };
+}

--- a/src/main.js
+++ b/src/main.js
@@ -1,0 +1,10 @@
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import App from './App.js';
+
+const root = createRoot(document.getElementById('root'));
+root.render(
+  <StrictMode>
+    <App />
+  </StrictMode>
+);


### PR DESCRIPTION
## Summary
- create minimal React prototype with Tailwind via CDN
- add broker income calculator component
- update README with basic run instructions
- clean out unused template files and simplify package.json

## Testing
- `npm start` *(fails: needs user input)*

------
https://chatgpt.com/codex/tasks/task_e_686c246f840c832c87cbecb387a3f5e9