### PR TITLE
Add interactive scenario prototype

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,11 +1,43 @@
+import { useState } from 'react';
 import Calculator from './components/Calculator.js';
+import MainMenu from './components/MainMenu.js';
+import ScenarioPlayer from './components/ScenarioPlayer.js';
+import Progress from './components/Progress.js';
 
 export default function App() {
+  const [view, setView] = useState('menu');
+  const [points, setPoints] = useState(0);
+
+  function addPoints(p) {
+    setPoints(prev => prev + p);
+  }
+
   return (
     <div className="p-4">
       <h1 className="text-2xl font-bold mb-4">DARK Leverage Sales Playbook</h1>
-      <p className="mb-4">Welcome! Adjust the values below to see potential income.</p>
-      <Calculator />
+      <Progress points={points} />
+      {view === 'menu' && <MainMenu onNavigate={setView} />}
+      {view === 'training' && (
+        <div>
+          <p className="mb-2">Welcome to the training! Start with this scenario.</p>
+          <button className="px-2 py-1 bg-blue-500 text-white rounded" onClick={() => setView('scenario')}>Begin Scenario</button>
+        </div>
+      )}
+      {view === 'scenario' && (
+        <ScenarioPlayer onComplete={() => setView('menu')} addPoints={addPoints} />
+      )}
+      {view === 'progress' && (
+        <div>
+          <p className="mb-2">You have {points} points.</p>
+          <button className="px-2 py-1 bg-blue-500 text-white rounded" onClick={() => setView('menu')}>Back to Menu</button>
+        </div>
+      )}
+      {view === 'resources' && (
+        <div>
+          <p className="mb-2">Resources will unlock as you progress.</p>
+          <button className="px-2 py-1 bg-blue-500 text-white rounded" onClick={() => setView('menu')}>Back to Menu</button>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/Calculator.js
+++ b/src/components/Calculator.js
@@ -15,15 +15,15 @@ export default function Calculator() {
     <div className="p-4 bg-white rounded shadow-md mt-4">
       <h2 className="text-xl font-semibold mb-2">Broker Income Calculator</h2>
       <div className="space-y-2">
-        <label className="block">
+        <label className="block" title="How many businesses you attempt to sell each year">
           Deals per year: {annualDeals}
           <input type="range" min="10" max="50" value={annualDeals} onChange={e => setAnnualDeals(parseInt(e.target.value, 10))} className="w-full" />
         </label>
-        <label className="block">
+        <label className="block" title="Typical sale price for your deals">
           Average deal size ($):
           <input type="number" value={averageDealSize} onChange={e => setAverageDealSize(parseInt(e.target.value, 10))} className="w-full border" />
         </label>
-        <label className="block">
+        <label className="block" title="Percentage of deals that successfully close">
           Success rate: {Math.round(successRate*100)}%
           <input type="range" min="0.2" max="0.7" step="0.01" value={successRate} onChange={e => setSuccessRate(parseFloat(e.target.value))} className="w-full" />
         </label>

--- a/src/components/MainMenu.js
+++ b/src/components/MainMenu.js
@@ -1,0 +1,12 @@
+import React from 'react';
+
+export default function MainMenu({ onNavigate }) {
+  return (
+    <div className="space-x-2 mb-4">
+      <button className="px-2 py-1 bg-blue-500 text-white rounded" onClick={() => onNavigate('training')}>Start Training</button>
+      <button className="px-2 py-1 bg-blue-500 text-white rounded" onClick={() => onNavigate('scenario')}>Practice Scenarios</button>
+      <button className="px-2 py-1 bg-blue-500 text-white rounded" onClick={() => onNavigate('progress')}>My Progress</button>
+      <button className="px-2 py-1 bg-blue-500 text-white rounded" onClick={() => onNavigate('resources')}>Resources</button>
+    </div>
+  );
+}

--- a/src/components/Progress.js
+++ b/src/components/Progress.js
@@ -1,0 +1,13 @@
+import React from 'react';
+
+export default function Progress({ points }) {
+  const percentage = Math.min(100, points);
+  return (
+    <div className="mb-4">
+      <div className="h-2 bg-gray-300 rounded">
+        <div className="h-2 bg-green-500 rounded" style={{ width: `${percentage}%` }}></div>
+      </div>
+      <p className="text-sm mt-1">Points: {points}</p>
+    </div>
+  );
+}

--- a/src/components/ScenarioPlayer.js
+++ b/src/components/ScenarioPlayer.js
@@ -1,0 +1,55 @@
+import { useState } from 'react';
+import Calculator from './Calculator.js';
+
+export default function ScenarioPlayer({ onComplete, addPoints }) {
+  const [step, setStep] = useState('intro');
+  const [showCalc, setShowCalc] = useState(false);
+  const [feedback, setFeedback] = useState('');
+
+  function choose(option) {
+    if (option === 'A') {
+      setFeedback('The client feels you gave up on them. No referral earned.');
+      addPoints(0);
+      setStep('end');
+    } else if (option === 'B') {
+      setFeedback('Great! They are curious about improving operations.');
+      addPoints(10);
+      setShowCalc(true);
+      setStep('calc');
+    } else {
+      setFeedback('Hiring more people increases cost without fixing processes.');
+      addPoints(0);
+      setStep('end');
+    }
+  }
+
+  return (
+    <div>
+      {step === 'intro' && (
+        <div className="space-y-4">
+          <p className="italic">A busy broker juggles calls all day. One client says they work 70 hours a week and still can\'t keep up.</p>
+          <div>
+            <p>How do you respond?</p>
+            <button className="block mt-2 px-2 py-1 bg-blue-500 text-white rounded" onClick={() => choose('A')}>A) Selling might not be right now.</button>
+            <button className="block mt-2 px-2 py-1 bg-blue-500 text-white rounded" onClick={() => choose('B')}>B) What if you could cut that to 35 hours and improve operations?</button>
+            <button className="block mt-2 px-2 py-1 bg-blue-500 text-white rounded" onClick={() => choose('C')}>C) Just hire more people.</button>
+          </div>
+        </div>
+      )}
+      {step === 'calc' && (
+        <div className="space-y-4">
+          <p>{feedback}</p>
+          <p>Use this calculator to show potential.</p>
+          <Calculator />
+          <button className="mt-4 px-2 py-1 bg-green-500 text-white rounded" onClick={() => {setStep('end'); onComplete();}}>Finish Scenario</button>
+        </div>
+      )}
+      {step === 'end' && (
+        <div className="space-y-4">
+          <p>{feedback}</p>
+          <button className="px-2 py-1 bg-blue-500 text-white rounded" onClick={onComplete}>Return to Menu</button>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add a minimal main menu component for navigation
- track user progress with a simple points bar
- implement `ScenarioPlayer` to walk through the first D.A.R.K. introduction
- enhance the calculator with explanatory tooltips

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686c32ab0e6c832c94a93c05da9f0ac3